### PR TITLE
Detect Wine

### DIFF
--- a/MassEffectModManagerCore/App.xaml.cs
+++ b/MassEffectModManagerCore/App.xaml.cs
@@ -91,6 +91,11 @@ namespace ME3TweaksModManager
             @"Windows 11 24H2"
         };
 
+        public static bool WineDetected;
+        public static Version WineDetectedVersion;
+        public static string WineHostKernelName;
+        public static Version WineHostKernelVersion;
+
         /// <summary>
         /// If telemetry has been flushed after checking if it is enabled.
         /// </summary>
@@ -128,6 +133,14 @@ namespace ME3TweaksModManager
 
             // We use our own implementation of this as we store data in ProgramData.
             MCoreFilesystem.GetAppDataFolder = M3Filesystem.GetAppDataFolder; // Do not change
+            
+            WineDetected = MUtilities.IsWineDetected();
+            if (WineDetected) {
+                WineDetectedVersion = MUtilities.WineGetVersion();
+                MUtilities.WineGetHostVersion(out string HostKernelName, out Version HostKernelVersion);
+                WineHostKernelName = HostKernelName;
+                WineHostKernelVersion = HostKernelVersion;
+            }
 
             var settingsExist = File.Exists(Settings.SettingsPath); //for init language
             try
@@ -224,6 +237,13 @@ namespace ME3TweaksModManager
                         {
                             CommandLinePending.PendingFeatureLevel = parsedCommandLineArgs.Value.FeatureLevel;
                         }
+                        if (parsedCommandLineArgs.Value.DisableWineWorkarouds)
+                        {
+                            CommandLinePending.PendingDisableWineWorkarouds = parsedCommandLineArgs.Value.DisableWineWorkarouds;
+                            // Override WineDetected
+                            WineDetected = false;
+                            M3Log.Warning(@"Wine Workarounds Disabled");
+                        }
                     }
                     else
                     {
@@ -259,6 +279,16 @@ namespace ME3TweaksModManager
                 M3Log.Information(@"Running as " + Environment.UserName);
                 M3Log.Information(@"Executable location: " + ExecutableLocation);
                 M3Log.Information(@"Operating system: " + RuntimeInformation.OSDescription);
+                if (WineDetected)
+                {
+                    M3Log.Information(@"Wine detected, running under Linux or MacOS");
+                    if (WineDetectedVersion != null)
+                    {
+                        M3Log.Information(@"Wine version: " + WineDetectedVersion.ToString());
+                        M3Log.Information($"Host Kernel: {WineHostKernelName} {WineHostKernelVersion.ToString()}");
+                    }
+                }
+
 
                 //Get build date
                 BuildHelper.ReadRuildInfo(new BuildHelper.BuildSigner[] { new BuildHelper.BuildSigner() { SigningName = @"Michael Perez", DisplayName = @"ME3Tweaks" } });
@@ -810,5 +840,8 @@ namespace ME3TweaksModManager
 
         [Option(@"featurelevel", HelpText = "Indicates the feature level a command line operation uses")]
         public double FeatureLevel { get; set; }
+
+        [Option(@"disablewineworkarounds", HelpText = "Disables Wine workarounds if Wine is detected. Used for Wine development.")]
+        public bool DisableWineWorkarouds { get; set; }
     }
 }

--- a/MassEffectModManagerCore/App.xaml.cs
+++ b/MassEffectModManagerCore/App.xaml.cs
@@ -91,10 +91,6 @@ namespace ME3TweaksModManager
             @"Windows 11 24H2"
         };
 
-        public static bool WineDetected;
-        public static Version WineDetectedVersion;
-        public static string WineHostKernelName;
-        public static Version WineHostKernelVersion;
 
         /// <summary>
         /// If telemetry has been flushed after checking if it is enabled.
@@ -134,12 +130,12 @@ namespace ME3TweaksModManager
             // We use our own implementation of this as we store data in ProgramData.
             MCoreFilesystem.GetAppDataFolder = M3Filesystem.GetAppDataFolder; // Do not change
             
-            WineDetected = MUtilities.IsWineDetected();
-            if (WineDetected) {
-                WineDetectedVersion = MUtilities.WineGetVersion();
+            WineWorkarounds.WineDetected = MUtilities.IsWineDetected();
+            if (WineWorkarounds.WineDetected) {
+                WineWorkarounds.WineDetectedVersion = MUtilities.WineGetVersion();
                 MUtilities.WineGetHostVersion(out string HostKernelName, out Version HostKernelVersion);
-                WineHostKernelName = HostKernelName;
-                WineHostKernelVersion = HostKernelVersion;
+                WineWorkarounds.WineHostKernelName = HostKernelName;
+                WineWorkarounds.WineHostKernelVersion = HostKernelVersion;
             }
 
             var settingsExist = File.Exists(Settings.SettingsPath); //for init language
@@ -239,9 +235,7 @@ namespace ME3TweaksModManager
                         }
                         if (parsedCommandLineArgs.Value.DisableWineWorkarounds)
                         {
-                            CommandLinePending.PendingDisableWineWorkarounds = parsedCommandLineArgs.Value.DisableWineWorkarounds;
-                            // Override WineDetected
-                            WineDetected = false;
+                            WineWorkarounds.WineDetected = false;
                             M3Log.Warning(@"Wine Workarounds Disabled");
                         }
                     }
@@ -279,13 +273,13 @@ namespace ME3TweaksModManager
                 M3Log.Information(@"Running as " + Environment.UserName);
                 M3Log.Information(@"Executable location: " + ExecutableLocation);
                 M3Log.Information(@"Operating system: " + RuntimeInformation.OSDescription);
-                if (WineDetected)
+                if (WineWorkarounds.WineDetected)
                 {
                     M3Log.Information(@"Wine detected, running under Linux or MacOS");
-                    if (WineDetectedVersion != null)
+                    if (WineWorkarounds.WineDetectedVersion != null)
                     {
-                        M3Log.Information(@"Wine version: " + WineDetectedVersion);
-                        M3Log.Information($"Host Kernel: {WineHostKernelName} {WineHostKernelVersion}");
+                        M3Log.Information(@"Wine version: " + WineWorkarounds.WineDetectedVersion);
+                        M3Log.Information($"Host Kernel: {WineWorkarounds.WineHostKernelName} {WineWorkarounds.WineHostKernelVersion}");
                     }
                 }
 

--- a/MassEffectModManagerCore/App.xaml.cs
+++ b/MassEffectModManagerCore/App.xaml.cs
@@ -237,9 +237,9 @@ namespace ME3TweaksModManager
                         {
                             CommandLinePending.PendingFeatureLevel = parsedCommandLineArgs.Value.FeatureLevel;
                         }
-                        if (parsedCommandLineArgs.Value.DisableWineWorkarouds)
+                        if (parsedCommandLineArgs.Value.DisableWineWorkarounds)
                         {
-                            CommandLinePending.PendingDisableWineWorkarouds = parsedCommandLineArgs.Value.DisableWineWorkarouds;
+                            CommandLinePending.PendingDisableWineWorkarounds = parsedCommandLineArgs.Value.DisableWineWorkarounds;
                             // Override WineDetected
                             WineDetected = false;
                             M3Log.Warning(@"Wine Workarounds Disabled");
@@ -284,8 +284,8 @@ namespace ME3TweaksModManager
                     M3Log.Information(@"Wine detected, running under Linux or MacOS");
                     if (WineDetectedVersion != null)
                     {
-                        M3Log.Information(@"Wine version: " + WineDetectedVersion.ToString());
-                        M3Log.Information($"Host Kernel: {WineHostKernelName} {WineHostKernelVersion.ToString()}");
+                        M3Log.Information(@"Wine version: " + WineDetectedVersion);
+                        M3Log.Information($"Host Kernel: {WineHostKernelName} {WineHostKernelVersion}");
                     }
                 }
 
@@ -842,6 +842,6 @@ namespace ME3TweaksModManager
         public double FeatureLevel { get; set; }
 
         [Option(@"disablewineworkarounds", HelpText = "Disables Wine workarounds if Wine is detected. Used for Wine development.")]
-        public bool DisableWineWorkarouds { get; set; }
+        public bool DisableWineWorkarounds { get; set; }
     }
 }

--- a/MassEffectModManagerCore/MainWindow.xaml.cs
+++ b/MassEffectModManagerCore/MainWindow.xaml.cs
@@ -2999,17 +2999,16 @@ namespace ME3TweaksModManager
             // MessageBox.Show(M3L.GetString(M3L.string_prereleaseNotice));
             // MessageBox.Show(M3L.GetString(M3L.string_betaBuildDialog));
 #endif
-
             // Todo: localize Wine message
-            if (App.WineDetected)
+            if (WineWorkarounds.WineDetected)
             {
                 var message = @"You're trying to run ME3Tweaks Mod Manager under Linux or MacOS, " +
                     @"please note that this is unsupported and you will not receive official support.";
 #if DEBUG
-                if (App.WineDetectedVersion != null)
+                if (WineWorkarounds.WineDetectedVersion != null)
                 {
-                    message += $"\n\nWine version: {App.WineDetectedVersion}";
-                    message += $"\nKernel: {App.WineHostKernelName} {App.WineHostKernelVersion}";
+                    message += $"\n\nWine version: {WineWorkarounds.WineDetectedVersion}";
+                    message += $"\nKernel: {WineWorkarounds.WineHostKernelName} {WineWorkarounds.WineHostKernelVersion}";
                 }
 #endif
                 M3L.ShowDialog(this, message, @"Wine detected", MessageBoxButton.OK);

--- a/MassEffectModManagerCore/MainWindow.xaml.cs
+++ b/MassEffectModManagerCore/MainWindow.xaml.cs
@@ -3000,16 +3000,34 @@ namespace ME3TweaksModManager
             // MessageBox.Show(M3L.GetString(M3L.string_betaBuildDialog));
 #endif
 
-            if (!App.IsOperatingSystemSupported())
+            // Todo: localize Wine message
+            if (App.WineDetected)
             {
-                string osList = string.Join("\n - ", App.SupportedOperatingSystemVersions); //do not localize
-                M3Log.Error(@"This operating system is not supported.");
-                M3L.ShowDialog(this, M3L.GetString(M3L.string_interp_dialog_unsupportedOS, osList),
-                    M3L.GetString(M3L.string_unsupportedOperatingSystem), MessageBoxButton.OK, MessageBoxImage.Error);
+                var message = @"Seems like you're trying to run ME3Tweaks Mod Manager under Linux or MacOS, " +
+                    @"please note that this is unsupported and you will not receive official support.";
+#if DEBUG
+                if (App.WineDetectedVersion != null)
+                {
+                    message += $"\n\nWine version: {App.WineDetectedVersion}";
+                    message += $"\nKernel: {App.WineHostKernelName} {App.WineHostKernelVersion}";
+                }
+#endif
+                MessageBoxResult result = M3L.ShowDialog(this, message, @"Wine detected", MessageBoxButton.OK);
             }
             else
             {
-                // Unimplemented last crash dialog code removed 03/28/2025
+
+                if (!App.IsOperatingSystemSupported())
+                {
+                    string osList = string.Join("\n - ", App.SupportedOperatingSystemVersions); //do not localize
+                    M3Log.Error(@"This operating system is not supported.");
+                    M3L.ShowDialog(this, M3L.GetString(M3L.string_interp_dialog_unsupportedOS, osList),
+                        M3L.GetString(M3L.string_unsupportedOperatingSystem), MessageBoxButton.OK, MessageBoxImage.Error);
+                }
+                else
+                {
+                    // Unimplemented last crash dialog code removed 03/28/2025
+                }
             }
 
             // Run on background thread as we don't need the result of this

--- a/MassEffectModManagerCore/MainWindow.xaml.cs
+++ b/MassEffectModManagerCore/MainWindow.xaml.cs
@@ -3003,7 +3003,7 @@ namespace ME3TweaksModManager
             // Todo: localize Wine message
             if (App.WineDetected)
             {
-                var message = @"Seems like you're trying to run ME3Tweaks Mod Manager under Linux or MacOS, " +
+                var message = @"You're trying to run ME3Tweaks Mod Manager under Linux or MacOS, " +
                     @"please note that this is unsupported and you will not receive official support.";
 #if DEBUG
                 if (App.WineDetectedVersion != null)
@@ -3012,7 +3012,7 @@ namespace ME3TweaksModManager
                     message += $"\nKernel: {App.WineHostKernelName} {App.WineHostKernelVersion}";
                 }
 #endif
-                MessageBoxResult result = M3L.ShowDialog(this, message, @"Wine detected", MessageBoxButton.OK);
+                M3L.ShowDialog(this, message, @"Wine detected", MessageBoxButton.OK);
             }
             else
             {

--- a/MassEffectModManagerCore/modmanager/WineWorkarounds.cs
+++ b/MassEffectModManagerCore/modmanager/WineWorkarounds.cs
@@ -1,0 +1,14 @@
+﻿using System.ComponentModel;
+
+namespace ME3TweaksModManager.modmanager
+{
+    [Localizable(false)]
+    public static class WineWorkarounds
+    {
+        public static bool WineDetected { get; set; }
+        public static Version WineDetectedVersion { get; set; }
+        public static string WineHostKernelName { get; set; }
+        public static Version WineHostKernelVersion { get; set; }
+
+    }
+}

--- a/MassEffectModManagerCore/modmanager/helpers/CommandLinePending.cs
+++ b/MassEffectModManagerCore/modmanager/helpers/CommandLinePending.cs
@@ -62,11 +62,6 @@
         public static string PendingMergeModCompileManifest;
 
         /// <summary>
-        /// Disable workarounds for Wine
-        /// </summary>
-        public static bool PendingDisableWineWorkarounds;
-
-        /// <summary>
         /// Sets PendingGame to null if there are no items in the pending system that depend on it
         /// </summary>
         public static void ClearGameDependencies()

--- a/MassEffectModManagerCore/modmanager/helpers/CommandLinePending.cs
+++ b/MassEffectModManagerCore/modmanager/helpers/CommandLinePending.cs
@@ -62,6 +62,11 @@
         public static string PendingMergeModCompileManifest;
 
         /// <summary>
+        /// Disable workarounds for Wine
+        /// </summary>
+        public static bool PendingDisableWineWorkarouds;
+
+        /// <summary>
         /// Sets PendingGame to null if there are no items in the pending system that depend on it
         /// </summary>
         public static void ClearGameDependencies()

--- a/MassEffectModManagerCore/modmanager/helpers/CommandLinePending.cs
+++ b/MassEffectModManagerCore/modmanager/helpers/CommandLinePending.cs
@@ -64,7 +64,7 @@
         /// <summary>
         /// Disable workarounds for Wine
         /// </summary>
-        public static bool PendingDisableWineWorkarouds;
+        public static bool PendingDisableWineWorkarounds;
 
         /// <summary>
         /// Sets PendingGame to null if there are no items in the pending system that depend on it


### PR DESCRIPTION
Set Wine related variables
Log the presence of Wine
Show a popup warning the user that Wine is not officially supported

`--disablewineworkarounds` is a new flag that can be used to override "WineDetected" and set it to false.

Changes depend on: https://github.com/ME3Tweaks/ME3TweaksCore/pull/28