### PR TITLE
Wine: Fix Folder selection dialogs

### DIFF
--- a/MassEffectModManagerCore/modmanager/helpers/M3PromptCallbacks.cs
+++ b/MassEffectModManagerCore/modmanager/helpers/M3PromptCallbacks.cs
@@ -1,11 +1,12 @@
-﻿using System.Collections.Generic;
+﻿using LegendaryExplorerCore.Packages;
+using ME3TweaksCore.Helpers;
+using ME3TweaksModManager.modmanager.localizations;
+using ME3TweaksModManager.modmanager.windows;
+using Microsoft.Win32;
+using Microsoft.WindowsAPICodePack.Dialogs;
 using System.Threading;
 using System.Windows;
 using System.Windows.Threading;
-using LegendaryExplorerCore.Packages;
-using ME3TweaksModManager.modmanager.localizations;
-using ME3TweaksModManager.modmanager.windows;
-using Microsoft.WindowsAPICodePack.Dialogs;
 
 namespace ME3TweaksModManager.modmanager.helpers
 {
@@ -185,15 +186,30 @@ namespace ME3TweaksModManager.modmanager.helpers
             Application.Current.Dispatcher.Invoke(() =>
             {
                 // Not sure if this has to be synced
-                CommonOpenFileDialog ofd = new CommonOpenFileDialog()
+                if (WineWorkarounds.WineDetected)
                 {
-                    Title = dialogTitle,
-                    IsFolderPicker = true,
-                    EnsurePathExists = true
-                };
-                if (ofd.ShowDialog() == CommonFileDialogResult.Ok)
+                    var ofd = new OpenFolderDialog
+                    {
+                        ValidateNames = true,
+                        Title = dialogTitle
+                    };
+                    if (ofd.ShowDialog() == true)
+                    {
+                        selectedPath = ofd.FolderName;
+                    }
+                }
+                else
                 {
-                    selectedPath = ofd.FileName;
+                    CommonOpenFileDialog ofd = new CommonOpenFileDialog
+                    {
+                        Title = dialogTitle,
+                        IsFolderPicker = true,
+                        EnsurePathExists = true
+                    };
+                    if (ofd.ShowDialog() == CommonFileDialogResult.Ok)
+                    {
+                        selectedPath = ofd.FileName;
+                    }
                 }
             });
             return selectedPath;

--- a/MassEffectModManagerCore/modmanager/loaders/M3LoadedMods.cs
+++ b/MassEffectModManagerCore/modmanager/loaders/M3LoadedMods.cs
@@ -9,6 +9,7 @@ using ME3TweaksModManager.modmanager.objects.launcher;
 using ME3TweaksModManager.modmanager.objects.mod;
 using ME3TweaksModManager.modmanager.objects.mod.interfaces;
 using ME3TweaksModManager.modmanager.objects.mod.texture;
+using Microsoft.Win32;
 using Microsoft.WindowsAPICodePack.Dialogs;
 using Newtonsoft.Json;
 using System.ComponentModel;
@@ -622,21 +623,42 @@ namespace ME3TweaksModManager.modmanager.loaders
             if (libraryType == MessageBoxResult.Yes)
             {
                 // Shared
-                CommonOpenFileDialog m = new CommonOpenFileDialog
+                if (WineWorkarounds.WineDetected)
                 {
-                    IsFolderPicker = true,
-                    EnsurePathExists = true,
-                    Title = M3L.GetString(M3L.string_selectModLibraryFolder)
-                };
-                if (m.ShowDialog(centeringWindow) == CommonFileDialogResult.Ok)
-                {
-                    Settings.ModLibraryPath = m.FileName;
-                    if (loadModsAfterSelecting)
+                    var m = new OpenFolderDialog
                     {
-                        Instance.LoadMods();
-                    }
+                        ValidateNames = true,
+                        Title = M3L.GetString(M3L.string_selectModLibraryFolder)
+                    };
+                    if (m.ShowDialog(centeringWindow) == true)
+                    {
+                        Settings.ModLibraryPath = m.FolderName;
+                        if (loadModsAfterSelecting)
+                        {
+                            Instance.LoadMods();
+                        }
 
-                    return true;
+                        return true;
+                    }
+                }
+                else
+                {
+                    CommonOpenFileDialog m = new CommonOpenFileDialog
+                    {
+                        IsFolderPicker = true,
+                        EnsurePathExists = true,
+                        Title = M3L.GetString(M3L.string_selectModLibraryFolder)
+                    };
+                    if (m.ShowDialog(centeringWindow) == CommonFileDialogResult.Ok)
+                    {
+                        Settings.ModLibraryPath = m.FileName;
+                        if (loadModsAfterSelecting)
+                        {
+                            Instance.LoadMods();
+                        }
+
+                        return true;
+                    }
                 }
             }
 

--- a/MassEffectModManagerCore/modmanager/objects/GameRestoreWrapper.cs
+++ b/MassEffectModManagerCore/modmanager/objects/GameRestoreWrapper.cs
@@ -10,6 +10,7 @@ using ME3TweaksCore.Services.Shared.BasegameFileIdentification;
 using ME3TweaksCoreWPF.Targets;
 using ME3TweaksCoreWPF.UI;
 using ME3TweaksModManager.modmanager.localizations;
+using Microsoft.Win32;
 using Microsoft.WindowsAPICodePack.Dialogs;
 
 namespace ME3TweaksModManager.modmanager.objects
@@ -128,15 +129,30 @@ namespace ME3TweaksModManager.modmanager.objects
                     Application.Current.Dispatcher.Invoke(() =>
                     {
                         // Not sure if this has to be synced
-                        CommonOpenFileDialog ofd = new CommonOpenFileDialog()
+                        if (WineWorkarounds.WineDetected)
                         {
-                            Title = M3L.GetString(M3L.string_selectNewRestoreDestination),
-                            IsFolderPicker = true,
-                            EnsurePathExists = true
-                        };
-                        if (ofd.ShowDialog() == CommonFileDialogResult.Ok)
+                            var ofd = new OpenFolderDialog
+                            {
+                                ValidateNames = true,
+                                Title = M3L.GetString(M3L.string_selectNewRestoreDestination)
+                            };
+                            if (ofd.ShowDialog() == true)
+                            {
+                                selectedPath = ofd.FolderName;
+                            }
+                        }
+                        else
                         {
-                            selectedPath = ofd.FileName;
+                            CommonOpenFileDialog ofd = new CommonOpenFileDialog()
+                            {
+                                Title = M3L.GetString(M3L.string_selectNewRestoreDestination),
+                                IsFolderPicker = true,
+                                EnsurePathExists = true
+                            };
+                            if (ofd.ShowDialog() == CommonFileDialogResult.Ok)
+                            {
+                                selectedPath = ofd.FileName;
+                            }
                         }
                     });
                     return selectedPath;

--- a/MassEffectModManagerCore/modmanager/usercontrols/OptionsPanel.xaml.cs
+++ b/MassEffectModManagerCore/modmanager/usercontrols/OptionsPanel.xaml.cs
@@ -2,6 +2,7 @@
 using System.Windows;
 using System.Windows.Input;
 using LegendaryExplorerCore.Misc;
+using ME3TweaksCore.Helpers;
 using ME3TweaksCoreWPF.UI;
 using ME3TweaksModManager.modmanager.localizations;
 using ME3TweaksModManager.modmanager.me3tweaks;
@@ -11,6 +12,8 @@ using ME3TweaksModManager.ui;
 #if WITH_APPCENTER
 using Microsoft.AppCenter.Analytics;
 using Microsoft.AppCenter.Crashes;
+using Microsoft.Win32;
+
 #endif
 using Microsoft.WindowsAPICodePack.Dialogs;
 
@@ -234,15 +237,30 @@ namespace ME3TweaksModManager.modmanager.usercontrols
                 }
                 else
                 {
-                    CommonOpenFileDialog m = new CommonOpenFileDialog
+                    if (WineWorkarounds.WineDetected)
                     {
-                        IsFolderPicker = true,
-                        EnsurePathExists = true,
-                        Title = M3L.GetString(M3L.string_selectNexusModsDownloadDirectory)
-                    };
-                    if (m.ShowDialog(window) == CommonFileDialogResult.Ok)
+                        var m = new OpenFolderDialog
+                        {
+                            ValidateNames = true,
+                            Title = M3L.GetString(M3L.string_selectNexusModsDownloadDirectory)
+                        };
+                        if (m.ShowDialog(window) == true)
+                        {
+                            Settings.ModDownloadCacheFolder = m.FolderName;
+                        }
+                    }
+                    else
                     {
-                        Settings.ModDownloadCacheFolder = m.FileName;
+                        CommonOpenFileDialog m = new CommonOpenFileDialog
+                        {
+                            IsFolderPicker = true,
+                            EnsurePathExists = true,
+                            Title = M3L.GetString(M3L.string_selectNexusModsDownloadDirectory)
+                        };
+                        if (m.ShowDialog(window) == CommonFileDialogResult.Ok)
+                        {
+                            Settings.ModDownloadCacheFolder = m.FileName;
+                        }
                     }
                 }
 


### PR DESCRIPTION
On update to 9.2 (possibly caused by the upgrade to .net 10), folder selection dialogs began causing a crash, this fixes that.

All of these are behind a WineDetected check to avoid affecting Windows users.