### PR TITLE
M3Utilities.OpenExplorer: Wrap path in quotes

### DIFF
--- a/MassEffectModManagerCore/modmanager/M3Utilities.cs
+++ b/MassEffectModManagerCore/modmanager/M3Utilities.cs
@@ -922,7 +922,7 @@ namespace ME3TweaksModManager.modmanager
         /// <param name="path">The directory path to open in Explorer.</param>
         internal static void OpenExplorer(string path)
         {
-            Process.Start("explorer", path);
+            Process.Start("explorer", $"\"{path}\"");
         }
 
         /// <summary>


### PR DESCRIPTION
Explorer was being passed a path without quotes, leading to some paths not being found.
Fixes #513 