### PR TITLE
Wine: replace default font with Arial, disable HWAccel

### DIFF
--- a/MassEffectModManagerCore/App.xaml.cs
+++ b/MassEffectModManagerCore/App.xaml.cs
@@ -24,6 +24,8 @@ using Serilog;
 using ME3TweaksModManager.modmanager.telemetry;
 using SevenZip;
 using SingleInstanceCore;
+using System.Windows.Interop;
+using System.Windows.Media;
 
 namespace ME3TweaksModManager
 {
@@ -245,9 +247,11 @@ namespace ME3TweaksModManager
                 this.Dispatcher.UnhandledException += OnDispatcherUnhandledException;
 
                 // Check if user explicitly disabled wine workarounds
-                if (!IGNORE_WINE) {
-                // Detect Wine earlier than CoreBoot so workarounds can be applied sooner
-                WineWorkarounds.Init();
+                if (!IGNORE_WINE)
+                {
+                    // Detect Wine earlier than CoreBoot so workarounds can be applied sooner
+                    WineWorkarounds.Init();
+                    RenderOptions.ProcessRenderMode = RenderMode.SoftwareOnly;
                 }
 
                 ToolTipService.ShowDurationProperty.OverrideMetadata(

--- a/MassEffectModManagerCore/MainWindow.xaml.cs
+++ b/MassEffectModManagerCore/MainWindow.xaml.cs
@@ -49,6 +49,7 @@ using System.Windows.Input;
 using System.Windows.Media.Animation;
 using System.Windows.Navigation;
 using System.Windows.Threading;
+using System.Windows.Media;
 using M3OnlineContent = ME3TweaksModManager.modmanager.me3tweaks.services.M3OnlineContent;
 using Mod = ME3TweaksModManager.modmanager.objects.mod.Mod;
 using StarterKitContentSelector = ME3TweaksModManager.modmanager.windows.dialog.StarterKitContentSelector;
@@ -372,6 +373,7 @@ namespace ME3TweaksModManager
             InitializeSingletons();
             LoadCommands();
             SetTheme(true);
+            SetWineUIDefaults(); // Setting before anything is drawn
             InitializeComponent();
             this.ApplyDarkNetWindowTheme();
 
@@ -533,6 +535,55 @@ namespace ME3TweaksModManager
             else
             {
                 M3Log.Information(@"settings.ini is writable");
+            }
+        }
+
+        /// <summary>
+        /// Updates the default Font Family of M3
+        /// </summary>
+        /// <param name="fontName"></param>
+        /// <returns></returns>
+        public static bool UpdateFontFamily(string fontName)
+        {
+            return UpdateFontFamily(new FontFamily(fontName));
+        }
+
+        /// <summary>
+        /// Updates the default Font Family of M3
+        /// </summary>
+        /// <param name="font"></param>
+        /// <returns></returns>
+        public static bool UpdateFontFamily(FontFamily font)
+        {
+            if (Application.Current.TryFindResource("M3DefaultFont") is FontFamily defaultFont)
+            {
+                Application.Current.Resources["M3DefaultFont"] = font;
+                M3Log.Information($"Updating font to {font.Source}");
+                return true;
+            }
+            else
+            {
+                M3Log.Warning($"Failed to set font to {font.Source}");
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Sets defaults 
+        /// </summary>
+        private static void SetWineUIDefaults()
+        {
+            // Override defaults if Wine is detected
+            if (WineWorkarounds.WineDetected)
+            {
+                if (Application.Current.TryFindResource(@"M3DefaultMenuItemMargin") is Thickness defMargin)
+                {
+                    // Hacky, would be nice to figure out how to get Wine to display margins (and padding) correctly
+                    defMargin.Left = defMargin.Left / 2;
+                    Application.Current.Resources[@"M3DefaultMenuItemMargin"] = defMargin;
+                    M3Log.Information($@"Wine: Setting menu category left margin to {defMargin.Left}");
+                }
+                UpdateFontFamily(@"Arial");
             }
         }
 

--- a/MassEffectModManagerCore/modmanager/helpers/RichTextHelper.cs
+++ b/MassEffectModManagerCore/modmanager/helpers/RichTextHelper.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Media;
 using ME3TweaksModManager.ui;
 
 namespace ME3TweaksModManager.modmanager.helpers
@@ -23,11 +25,21 @@ namespace ME3TweaksModManager.modmanager.helpers
         public static string GetHeader()
         {
             var fontSizeToUse = 18;
+            var fontFamilyToUse = @"Segoe UI";
+            if (Application.Current.TryFindResource(@"M3DefaultFont") is FontFamily defaultM3Font)
+            {
+                M3Log.Information($@"Found rich text font - {defaultM3Font.Source}");
+                fontFamilyToUse = defaultM3Font.Source;
+            }
+            else
+            {
+                M3Log.Error(@"Failed to get rich text font");
+            }
 
             // Apply Windows text scale factor (from Accessibility settings)
             fontSizeToUse = (int)Math.Round(fontSizeToUse * DPIScaling.TextScaleFactor);
 
-            return @"{\rtf1\ansi\deff0{\fonttbl{\f0 Segoe UI;}}\fs" + fontSizeToUse + @" "; // Must contain space on the end
+            return @"{\rtf1\ansi\deff0{\fonttbl{\f0 " + fontFamilyToUse + @";}}\fs" + fontSizeToUse + @" "; // Must contain space on the end
         }
 
         public static string GetFooter()

--- a/MassEffectModManagerCore/ui/MMStyles.xaml
+++ b/MassEffectModManagerCore/ui/MMStyles.xaml
@@ -2,7 +2,9 @@
                     x:Class="ME3TweaksModManager.ui.MMStyles"
                     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:adonisControls="clr-namespace:AdonisUI.Controls;assembly=AdonisUI"
                     xmlns:adonisUi="clr-namespace:AdonisUI;assembly=AdonisUI"
+                    xmlns:sys="clr-namespace:System;assembly=mscorlib"
                     xmlns:system="clr-namespace:System;assembly=System.Runtime"
                     xmlns:fa5="http://schemas.fontawesome.com/icons/"
                     xmlns:targets="clr-namespace:ME3TweaksCore.Targets;assembly=ME3TweaksCore"
@@ -43,6 +45,10 @@
     <converters1:BoolToDimmedOpacityConverter x:Key="BoolToDimmedOpacityConverter"/>
     <converters1:IntGreaterThanConverter x:Key="IntGreaterThanConverter"/>
 
+    <FontFamily x:Key="M3DefaultFont">Segoe UI</FontFamily>
+    <sys:Double x:Key="M3DefaultFontSize">12</sys:Double>
+    <Thickness x:Key="M3DefaultMenuItemMargin">-30,0,0,0</Thickness>
+
     <Style x:Key="TargetSelectorContainerStyle" TargetType="ComboBoxItem" BasedOn="{StaticResource {x:Type ComboBoxItem}}">
         <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
         <Setter Property="IsEnabled" Value="{Binding Selectable}" />
@@ -51,12 +57,30 @@
         <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
         <Setter Property="IsEnabled" Value="{Binding Selectable}" />
     </Style>
+
+    <Style TargetType="{x:Type TextBlock}" BasedOn="{StaticResource {x:Type TextBlock}}">
+        <Setter Property="FontFamily" Value="{DynamicResource M3DefaultFont}" />
+        <Setter Property="FontSize" Value="{DynamicResource M3DefaultFontSize}" />
+    </Style>
+    <Style TargetType="{x:Type ToolTip}" BasedOn="{StaticResource {x:Type ToolTip}}">
+        <Setter Property="FontFamily" Value="{DynamicResource M3DefaultFont}" />
+        <Setter Property="FontSize" Value="{DynamicResource M3DefaultFontSize}" />
+    </Style>
+    <Style TargetType="Window" BasedOn="{StaticResource {x:Type Window}}">
+        <Setter Property="FontFamily" Value="{DynamicResource M3DefaultFont}" />
+        <Setter Property="FontSize" Value="{DynamicResource M3DefaultFontSize}" />
+    </Style>
+
+    <Style TargetType="{x:Type adonisControls:MessageBoxWindow}" BasedOn="{StaticResource {x:Type adonisControls:MessageBoxWindow}}">
+        <Setter Property="FontFamily" Value="{DynamicResource M3DefaultFont}" />
+        <Setter Property="FontSize" Value="{DynamicResource M3DefaultFontSize}" />
+    </Style>
     <Style
         x:Key="MenuItemHeaderStyle"
         TargetType="{x:Type MenuItem}">
         <Setter
             Property="Margin"
-            Value="-30,0,0,0" />
+            Value="{DynamicResource M3DefaultMenuItemMargin}" />
         <Setter
             Property="FontSize"
             Value="10" />


### PR DESCRIPTION
- Added controls for setting M3's font family from one place. Default is Segoe UI.
- If Wine is detected, M3's font family will be changed to Arial (guaranteed to be present in every Wine prefix).
- Disable hardware acceleration if Wine is detected. This fixes some visual artifacts like black boxes.

Down the line it may be worth adding a check if Segoe UI is installed, and perhaps install it (or a similar font) for the user.