### PR TITLE
Font fixes

### DIFF
--- a/MassEffectModManagerCore/linux/WineWorkaroundsM3.cs
+++ b/MassEffectModManagerCore/linux/WineWorkaroundsM3.cs
@@ -1,4 +1,6 @@
 ﻿using ME3TweaksCore.Helpers;
+using Microsoft.Win32;
+using System.Security.AccessControl;
 using System.Windows;
 using System.Windows.Interop;
 using System.Windows.Media;
@@ -67,6 +69,23 @@ namespace ME3TweaksModManager.linux
             // Override defaults if Wine is detected
             if (WineWorkarounds.WineDetected)
             {
+
+                // Remove Wine keys responsible for faking an installed "Segoe UI"
+                using (RegistryKey FontReplacements = Registry.CurrentUser.OpenSubKey(@"Software\Wine\Fonts\Replacements", true))
+                {
+                    if (FontReplacements != null) {
+                        if (FontReplacements.GetValueNames().Contains("Segoe UI"))
+                        {
+                            FontReplacements.DeleteValue("Segoe UI");
+                            M3Log.Information("Deleting Wine's replacement key for Segoe UI");
+                        }
+                        if (FontReplacements.GetValueNames().Contains("Segoe UI Semibold"))
+                        {
+                            FontReplacements.DeleteValue("Segoe UI Semibold");
+                            M3Log.Information("Deleting Wine's replacement key for Segoe UI Semibold");
+                        }
+                    }
+                }
                 if (Application.Current.TryFindResource(@"M3DefaultMenuItemMargin") is Thickness defMargin)
                 {
                     // Hacky, would be nice to figure out how to get Wine to display margins (and padding) correctly

--- a/MassEffectModManagerCore/ui/MMStyles.xaml
+++ b/MassEffectModManagerCore/ui/MMStyles.xaml
@@ -60,6 +60,8 @@
 
     <Style TargetType="{x:Type TextBlock}" BasedOn="{StaticResource {x:Type TextBlock}}">
         <Setter Property="FontFamily" Value="{DynamicResource M3DefaultFont}" />
+    </Style>
+    <Style TargetType="{x:Type Menu}" BasedOn="{StaticResource {x:Type Menu}}">
         <Setter Property="FontSize" Value="{DynamicResource M3DefaultFontSize}" />
     </Style>
     <Style TargetType="{x:Type ToolTip}" BasedOn="{StaticResource {x:Type ToolTip}}">


### PR DESCRIPTION
- Font size was being applied to everything because the `TextBox` font size would override any inherited sizes
- Wine: Remove Segoe UI keys in `Software\Wine\Fonts\Replacements` if detected. This allows M3 to fall back to Arial if Segoe UI isn't installed on the host